### PR TITLE
Changing batch scripts for SVMBIR jobs

### DIFF
--- a/backend/ALS_batch_recon.py
+++ b/backend/ALS_batch_recon.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import ALS_recon_functions as als
 import ALS_recon_helper as helper
 
-MAX_JOB_SECONDS = 80*60 # 1 hour 20 min
+MAX_JOB_SECONDS = 300*60 # 5 hour 00 min
 
 def get_batch_template(algorithm="astra"):
     """ Gets path to appropriate batch scrpit template, depending on whether using Astra or SVMBIR, on Cori or Perlmutter """

--- a/backend/ALS_recon_functions.py
+++ b/backend/ALS_recon_functions.py
@@ -481,8 +481,18 @@ def cache_svmbir_projector(num_rays,num_angles,save_to_default_cache=True):
 
         
 def get_svmbir_cache_dir():
-    """ Sets location of SVMBIR system matrix cache. Must be accessible by all users, otherwise SVMBIR will take prohibitively long """
-    return '//global/cfs/cdirs/als/users/tomography_notebooks/svmbir_cache'
+    """ Sets location of SVMBIR system matrix cache. Must be accessible by all users, otherwise SVMBIR will take prohibitively long
+    If the global cache directory does raise a permission error, you can set the cache directory to your scratch directory by setting up cache_path as follows:
+    For Perlmutter:
+        cache_path = '/pscratch/sd/h/*YOUR_USER_NAME*/svmbir_cache'
+    For Cori:
+        cache_path = '/global/cscratch1/sd/h/*YOUR_USER_NAME*/svmbir_cache'
+    ---------------
+    Returns:
+        _type_: globally accessible file path to SVMBIR cache
+    """    
+    cache_path =  '//global/cfs/cdirs/als/users/tomography_notebooks/svmbir_cache'
+    return cache_path
 
 def get_scratch_path():
     """ Gets path to user's scratch if on NERSC, otherwise returns current directory """

--- a/slurm_scripts/svmbir_template_job-cori.txt
+++ b/slurm_scripts/svmbir_template_job-cori.txt
@@ -4,10 +4,11 @@
 #SBATCH --image=dperl/als832:mpi
 #SBATCH --volume=/global/cfs/cdirs/als/data_mover/share/<username>:/alsuser;/global/cfs/cdirs/als/data_mover/8.3.2/raw:/alsdata:ro
 #SBATCH -C haswell
-#SBATCH -N 100
-#SBATCH -n 100
+#SBATCH -N 10
+#SBATCH -n 10
 #SBATCH --ntasks-per-node 1
 #SBATCH --cpus-per-task 32
+#SBATCH --mem 96000
 #SBATCH --time=00:15:00
 #SBATCH -J als832-svmbir
 

--- a/slurm_scripts/svmbir_template_job-perlmutter.txt
+++ b/slurm_scripts/svmbir_template_job-perlmutter.txt
@@ -4,8 +4,8 @@
 #SBATCH --image=dperl/als832:mpi
 #SBATCH --volume=/global/cfs/cdirs/als/data_mover/share/<username>:/alsuser;/global/cfs/cdirs/als/data_mover/8.3.2/raw:/alsdata:ro
 #SBATCH -C cpu
-#SBATCH -N 100
-#SBATCH -n 100
+#SBATCH -N 10
+#SBATCH -n 10
 #SBATCH --ntasks-per-node 1
 #SBATCH --cpus-per-task 256
 #SBATCH --time=00:15:00


### PR DESCRIPTION
slurm_scripts/svmbir_template_job-cori.txt - changing the number of nodes and allocating enough memory for jobs running on Cori
slurm_scripts/svmbir_template_job-perlmutter.txt - changing the number of nodes 
backend/ALS_batch_recon.py - increasing the max job time
backend/ALS_recon_functions.py - updating cache path docstring for 